### PR TITLE
Add tag-based LCD discovery and update documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,11 @@
 # SpaceEngineers_ResourceLCD
 Space Engineers programmable block script that shows sorted ore and ingot totals on separate LCDs with aligned columns.
+
+## Panel setup
+
+Add the following tags to LCD panels you want the script to manage:
+
+* `[ResLCD Ore]` – displays the ore summary on every tagged panel.
+* `[ResLCD Ingot]` – displays the ingot summary on every tagged panel.
+
+You can place the tag in the panel's **Edit text** field or in its **Custom Data**. The script will copy the tag into Custom Data so panels stay registered after the script updates their display.

--- a/script.cs
+++ b/script.cs
@@ -39,7 +39,8 @@ void Rescan()
     for (int i = 0; i < cachedPanels.Count; i++)
     {
         var panel = cachedPanels[i];
-        var surface = panel.GetSurface(0);
+        var surface = GetPrimarySurface(panel);
+        if (surface == null) continue;
         bool added = false;
         if (PanelHasTag(panel, surface, ORE_PANEL_TAG))
         {
@@ -211,6 +212,7 @@ bool filterPanels(IMyTextPanel panel) { return panel.CubeGrid == Me.CubeGrid; }
 
 bool PanelHasTag(IMyTextPanel panel, IMyTextSurface surface, string tag)
 {
+    if (surface == null) return false;
     string customData = panel.CustomData;
     if (ContainsTag(customData, tag)) return true;
 
@@ -233,6 +235,11 @@ void PersistTag(IMyTextPanel panel, string tag, string existingCustomData)
 bool ContainsTag(string source, string tag)
 {
     return !string.IsNullOrEmpty(source) && source.IndexOf(tag, System.StringComparison.OrdinalIgnoreCase) >= 0;
+}
+
+IMyTextSurface GetPrimarySurface(IMyTextPanel panel)
+{
+    return panel as IMyTextSurface;
 }
 
 bool filterInventories(IMyTerminalBlock block)


### PR DESCRIPTION
## Summary
- switch LCD discovery to tag-based registration and cache matching text surfaces
- update output logic to drive every tagged panel and highlight low ice across all surfaces
- document the new `[ResLCD Ore]` and `[ResLCD Ingot]` tags for configuring panels

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68c88ea265c48333b99a999b7009a1de