### PR TITLE
Simplify item amount parsing

### DIFF
--- a/script.cs
+++ b/script.cs
@@ -199,7 +199,7 @@ string FormatQty(float v, bool forceInteger)
 
 float getItemAmountAsFloat(MyInventoryItem item)
 {
-    float count = 0f; float.TryParse("" + item.Amount, out count); return count;
+    return (float)item.Amount;
 }
 
 string PadRight(string input, int num)


### PR DESCRIPTION
## Summary
- simplify getItemAmountAsFloat by directly casting the item amount to float

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68c90d552c3083339b2b3eeadc0adb52