### PR TITLE
Use built-in PadRight

### DIFF
--- a/script.cs
+++ b/script.cs
@@ -185,7 +185,7 @@ string BuildPanelText(IDictionary<string,float> dict, bool isOre)
         string qty = FormatQty(kvp.Value, isIce);
         string label = kvp.Key + ": ";
         if (text.Length > 0) text += NL;
-        text += PadRight(label, labelWidth) + qty;
+        text += label.PadRight(labelWidth) + qty;
     }
     return text;
 }
@@ -200,12 +200,6 @@ string FormatQty(float v, bool forceInteger)
 float getItemAmountAsFloat(MyInventoryItem item)
 {
     float count = 0f; float.TryParse("" + item.Amount, out count); return count;
-}
-
-string PadRight(string input, int num)
-{
-    if (input.Length < num) for (int i = input.Length; i < num; i++) input += " ";
-    return input;
 }
 
 IEnumerable<IMyInventory> EnumerateInventories(IMyTerminalBlock block)


### PR DESCRIPTION
## Summary
- update BuildPanelText to use string.PadRight directly
- remove the unused PadRight helper

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68c90d5591a4833383d353a76accb929